### PR TITLE
Code Refactor Keep Unit Interfaces Small 

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,4 @@
+component_depth: 12
+languages:
+- typescript
+- javascript

--- a/src/lib/appEventPortal/appEventPortal.spec.ts
+++ b/src/lib/appEventPortal/appEventPortal.spec.ts
@@ -32,7 +32,7 @@ test.before(() => {
   event = new EventFoundation(params);
 
   const reduxStrategy: ReduxStrategy = new ReduxStrategy(mockStore);
-  appEventPortal = new AppEventPortal(reduxStrategy, appName);
+  appEventPortal = new AppEventPortal({ strategy: reduxStrategy, appName });
   appEventPortal.listenEvent(params.eventType);
 });
 

--- a/src/lib/appEventPortal/appEventPortal.ts
+++ b/src/lib/appEventPortal/appEventPortal.ts
@@ -47,13 +47,13 @@ export class AppEventPortal extends EventPortal {
   ): EventPortal {
     const callBack = (event: any) => {
       this.traceLogs.logNotifiedEvent(this.appName, event);
-      strategyCallBack.onNotification.call(strategyCallBack, event);
+      strategyCallBack.onNotification.call(strategyCallBack, event); // Avoiding scoping problems
     };
 
-    this.eventTarget.subscribeEventListener(
-      eventName,
-      callBack // Avoiding scoping problems
-    );
+    this.eventTarget.subscribeEventListener({
+      listener: callBack,
+      type: eventName
+    });
 
     return this;
   }

--- a/src/lib/appEventPortal/appEventPortal.ts
+++ b/src/lib/appEventPortal/appEventPortal.ts
@@ -19,11 +19,23 @@ export class AppEventPortal extends EventPortal {
   // Application name
   private readonly appName: string;
 
-  constructor(
-    strategy: NotificationStrategyFoundation,
-    appName: string,
-    tracesInstance?: Traces
-  ) {
+  /**
+   * Creates AppEventPortal instance objects
+   *
+   * @param {Object} constructorObject
+   * @param {NotificationStrategyFoundation} constructorObject.strategy - NotificationStrategyFoundation instance object to use on notification times
+   * @param {string} constructorObject.appName - The application name
+   * @param {Traces} constructorObject.tracesInstance -  Traces Instance object to store all the publishing and notification events
+   */
+  constructor({
+    strategy,
+    appName,
+    tracesInstance
+  }: {
+    strategy: NotificationStrategyFoundation;
+    appName: string;
+    tracesInstance?: Traces;
+  }) {
     super(strategy);
     this.appName = appName;
     if (tracesInstance) {

--- a/src/lib/eventPortal/eventPortal.ts
+++ b/src/lib/eventPortal/eventPortal.ts
@@ -70,10 +70,10 @@ export class EventPortal {
     eventName: string,
     strategyCallBack: any = this.notificationStrategy // TODO: Check how to change the 'any' for 'NotificationStrategyFoundation' as proper type
   ): EventPortal {
-    this.eventTarget.subscribeEventListener(
-      eventName,
-      strategyCallBack.onNotification.bind(strategyCallBack) // Avoiding scoping problems
-    );
+    this.eventTarget.subscribeEventListener({
+      listener: strategyCallBack.onNotification.bind(strategyCallBack), // Avoiding scoping problems
+      type: eventName
+    });
 
     return this;
   }

--- a/src/lib/eventTargetFoundation/eventTargetFoundation.spec.ts
+++ b/src/lib/eventTargetFoundation/eventTargetFoundation.spec.ts
@@ -27,10 +27,10 @@ test('Should publish event properly', t => {
   let eventPublished = {} as CustomEvent;
   const eventSubscriptionHandler = (e: CustomEvent) => (eventPublished = e);
 
-  eventTarget.subscribeEventListener(
-    eventName,
-    eventSubscriptionHandler as any
-  );
+  eventTarget.subscribeEventListener({
+    listener: eventSubscriptionHandler as any,
+    type: eventName
+  });
   eventTarget.publishEvent(event.getEvent());
 
   t.deepEqual(eventPublished.detail, {
@@ -44,15 +44,15 @@ test('Should unsubscribe event properly', t => {
     eventPublished = e;
   }
 
-  eventTarget.subscribeEventListener(
-    eventName,
-    eventSubscriptionHandler as any
-  );
+  eventTarget.subscribeEventListener({
+    listener: eventSubscriptionHandler as any,
+    type: eventName
+  });
 
-  eventTarget.unsubscribeEventListener(
-    eventName,
-    eventSubscriptionHandler as any
-  );
+  eventTarget.unsubscribeEventListener({
+    callback: eventSubscriptionHandler as any,
+    type: eventName
+  });
 
   eventTarget.publishEvent(event.getEvent());
 

--- a/src/lib/eventTargetFoundation/eventTargetFoundation.ts
+++ b/src/lib/eventTargetFoundation/eventTargetFoundation.ts
@@ -41,30 +41,40 @@ export class EventTargetFoundation {
   /**
    * Method to subscribe/register a listener to a given event
    *
-   * @param {string} type The event type/name to which the client wants to be subscribed.
-   * @param {function} listener Callback function to invoke each time the event of interest is published
-   * @param {boolean | object} options Subscription configuration. Optional.
+   * @param {Object} subscribingObject
+   * @param {string} subscribingObject.type The event type/name to which the client wants to be subscribed.
+   * @param {function} subscribingObject.listener Callback function to invoke each time the event of interest is published
+   * @param {boolean | object} subscribingObject.options Subscription configuration. Optional.
    */
-  public subscribeEventListener(
-    type: string,
-    listener: EventListenerOrEventListenerObject | null,
-    options?: boolean | AddEventListenerOptions
-  ): void {
+  public subscribeEventListener({
+    type,
+    listener,
+    options
+  }: {
+    type: string;
+    listener: EventListenerOrEventListenerObject | null;
+    options?: boolean | AddEventListenerOptions;
+  }): void {
     return this.eventTarget.addEventListener(type, listener, options);
   }
 
   /**
    * Method to un-subscribe/un-register a listener to a given event
    *
-   * @param {string} type The event type/name to which the client wants to be un-subscribed.
-   * @param {function} listener Callback function to invoke each time the event of interest is published. Same used on subscription time.
-   * @param {boolean | object} options Subscription configuration. Optional. Same used on subscription time.
+   * @param {Object} unsubscribingObject
+   * @param {string} unsubscribingObject.type The event type/name to which the client wants to be un-subscribed.
+   * @param {function} unsubscribingObject.listener Callback function to invoke each time the event of interest is published. Same used on subscription time.
+   * @param {boolean | object} unsubscribingObject.options Subscription configuration. Optional. Same used on subscription time.
    */
-  public unsubscribeEventListener(
-    type: string,
-    callback: EventListenerOrEventListenerObject | null,
-    options?: EventListenerOptions | boolean
-  ): void {
+  public unsubscribeEventListener({
+    type,
+    callback,
+    options
+  }: {
+    type: string;
+    callback: EventListenerOrEventListenerObject | null;
+    options?: EventListenerOptions | boolean;
+  }): void {
     return this.eventTarget.removeEventListener(type, callback, options);
   }
 }

--- a/src/lib/factories/appsPortalFactory/appsPortalFactory.ts
+++ b/src/lib/factories/appsPortalFactory/appsPortalFactory.ts
@@ -48,6 +48,6 @@ export class AppsPortalFactory {
         throw new Error('Unsupported strategy notification type.');
     }
 
-    return new AppEventPortal(strategy, appName, traceLogs);
+    return new AppEventPortal({ strategy, appName, tracesInstance: traceLogs });
   }
 }

--- a/src/lib/traces/traces.ts
+++ b/src/lib/traces/traces.ts
@@ -43,7 +43,11 @@ export class Traces {
    * @param {CustomEvent} event - Published event
    */
   public logPublishedEvent(publisherName: string, event: CustomEvent): void {
-    this.saveAppLogByActionType(publisherName, event, ActionType.Publishing);
+    this.saveAppLogByActionType({
+      actionType: ActionType.Publishing,
+      appName: publisherName,
+      event
+    });
   }
 
   /**
@@ -53,7 +57,11 @@ export class Traces {
    * @param {CustomEvent} event - Published event
    */
   public logNotifiedEvent(subscriberName: string, event: CustomEvent): void {
-    this.saveAppLogByActionType(subscriberName, event, ActionType.Notifying);
+    this.saveAppLogByActionType({
+      actionType: ActionType.Notifying,
+      appName: subscriberName,
+      event
+    });
   }
 
   /**
@@ -111,15 +119,20 @@ export class Traces {
   /**
    * Save an app log into the corresponding action type section.
    *
-   * @param {string} publisherName - Name of the micro frontend app or component which published the event
-   * @param {CustomEvent} event - Published event
-   * @param {ActionType = 'published' | 'notified'} actionType The log action type
+   * @param {Object} saveAppLogObject
+   * @param {string} saveAppLogObject.publisherName - Name of the micro frontend app or component which published the event
+   * @param {CustomEvent} saveAppLogObject.event - Published event
+   * @param {ActionType = 'published' | 'notified'} saveAppLogObject.actionType The log action type
    */
-  private saveAppLogByActionType(
-    appName: string,
-    event: CustomEvent,
-    actionType: ActionType
-  ): void {
+  private saveAppLogByActionType({
+    appName,
+    event,
+    actionType
+  }: {
+    appName: string;
+    event: CustomEvent;
+    actionType: ActionType;
+  }): void {
     const isPublishingTrace = actionType === ActionType.Publishing;
     const appLogs = isPublishingTrace
       ? this.getPublishedLogsByPublisherName(appName)
@@ -132,7 +145,11 @@ export class Traces {
 
     appLogs.set(event.type, newEventLog);
 
-    this.updateActionTypeLogByAppName(appName, appLogs, isPublishingTrace);
+    this.updateActionTypeLogByAppName({
+      appName,
+      isPublishingTrace,
+      publishedEventsMap: appLogs
+    });
   }
 
   /**
@@ -190,15 +207,20 @@ export class Traces {
   /**
    * Method to update an app notified or published events log.
    *
-   * @param {string} appName - Name of the micro frontend app or component which published the event
-   * @param {Map<string, any>} publishedEventsMap - Map object containing the published events log for this publisher
-   * @param {boolean} isPublishingTrace - Use to determine what part of the map update
+   * @param {Object} updateActionLogObject
+   * @param {string} updateActionLogObject.appName - Name of the micro frontend app or component which published the event
+   * @param {Map<string, any>} updateActionLogObject.publishedEventsMap - Map object containing the published events log for this publisher
+   * @param {boolean} updateActionLogObject.isPublishingTrace - Use to determine what part of the map update
    */
-  private updateActionTypeLogByAppName(
-    appName: string,
-    publishedEventsMap: Map<string, any>,
-    isPublishingTrace: boolean
-  ): void {
+  private updateActionTypeLogByAppName({
+    appName,
+    publishedEventsMap,
+    isPublishingTrace
+  }: {
+    appName: string;
+    publishedEventsMap: Map<string, any>;
+    isPublishingTrace: boolean;
+  }): void {
     let newActionTypeEventsLog: Map<string, any>;
     const actionType: ActionType = isPublishingTrace
       ? ActionType.Publishing


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

_Refactored classes:_
1. EventTargetFoundation
2. Traces
3. EventPortal

_Guideline explanation:_

* Keeping the number of parameters low makes units easier to understand and reuse.
* Limit the number of parameters per unit to at most 2.
* The number of parameters can be reduced by grouping related parameters into objects.
* Alternatively, try extracting parts of units that require fewer parameters.
* The list of refactoring candidates contains the top 30 of units that
violate this guideline, sorted by severity.
The severity is indicated by the colors of the checkboxes.



* **What is the current behavior?** 

_Currently situation:_
> From [bettercodehub.com](https://bettercodehub.com/results/rproenza86/micro-frontend-events-portal)

![image](https://user-images.githubusercontent.com/8029755/65823495-62288200-e225-11e9-9fe5-140f4162bc84.png)


* **What is the new behavior (if this is a feature change)?**

Each unit interface will have at top 2 parameters.

